### PR TITLE
Add new feature to display message to RSVPed user

### DIFF
--- a/pages/my-rsvps/past.js
+++ b/pages/my-rsvps/past.js
@@ -30,6 +30,10 @@ export default function MyPastRSVPs() {
     variables: { id },
   });
 
+  const pastRsvps = data?.account?.rsvps.filter(
+    (rsvp) => rsvp.event.eventTimestamp < currentTimestamp
+  );
+
   if (loading)
     return (
       <Dashboard page="rsvps" isUpcoming={false}>
@@ -48,7 +52,9 @@ export default function MyPastRSVPs() {
     <Dashboard page="rsvps" isUpcoming={false}>
       {account ? (
         <div>
-          {data && !data.account && <p>No past RSVPs found</p>}
+          {data && (!data.account || pastRsvps.length == 0) && (
+            <p>No past RSVPs found</p>
+          )}
           {data && data.account && (
             <ul
               role="list"


### PR DESCRIPTION
The users who interacted with the contract to createNewRSVP won't see the message "No past RSVPs found" on the page `my-rsvps/past.js`because `{data && !data.account && <p>No past RSVPs found</p>}` won't pass. 


We can display the message to them with another conditional statement.